### PR TITLE
RDKB-61157: Something has screwed up error in PAM

### DIFF
--- a/jsts/php.jst
+++ b/jsts/php.jst
@@ -296,6 +296,8 @@ function strlen($str)
 
 function explode($sep, $str)
 {
+  // For EMPTY $str return [] instead of [0:""]
+  if($str=="") return [];
   if(typeof($str) !== "undefined"){
     return $str.split($sep);
   }


### PR DESCRIPTION
Reason for change: https://gerrit.teamccp.com/#/c/921933/
Something has screwed up error in PAM when editing added devices in devices page
In jsts/php.jst explode() function definition, for EMPTY $str return [] instead of [0:""]

Test Procedure: Test for editing added devices in devices page

Risks:low
Priority: P1
Signed-off-by: pavankumarreddy_balireddy@comcast.com