### PR TITLE
RDKB-65950 Fix HTTP login session cookie Secure flag handling

### DIFF
--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -76,7 +76,7 @@
       {
         "name": "dbus",
         "repo": "https://github.com/deepin-community/dbus.git",
-        "branch" : "1.14.10-3-1deepin3",
+        "branch" : "master",
         "build": {
           "type": "cmake",
           "build_dir": "build",

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -76,7 +76,7 @@
       {
         "name": "dbus",
         "repo": "https://github.com/deepin-community/dbus.git",
-        "branch" : "master",
+        "branch" : "1.14.10-3-1deepin3",
         "build": {
           "type": "cmake",
           "build_dir": "build",

--- a/jsts/jst_prefix.js
+++ b/jsts/jst_prefix.js
@@ -110,10 +110,10 @@ function session_start()
     return;
   }
   ccsp_session.start();
+  var $session_id = ccsp_session.getId();
+  var $cookie = "Set-Cookie: DUKSID=" + $session_id + "; httponly";
   if (is_https_request())
-    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; secure" + "; httponly";
-  else
-    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
+    $cookie = "Set-Cookie: DUKSID=" + $session_id + "; secure; httponly";
   header($cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {
@@ -137,10 +137,10 @@ function session_start()
 }
 function session_create(){
   ccsp_session.create();
+  var $session_id = ccsp_session.getId();
+  var $cookie = "Set-Cookie: DUKSID=" + $session_id + "; httponly";
   if (is_https_request())
-    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; secure" + "; httponly";
-  else
-    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
+    $cookie = "Set-Cookie: DUKSID=" + $session_id + "; secure; httponly";
   header($cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {

--- a/jsts/jst_prefix.js
+++ b/jsts/jst_prefix.js
@@ -89,6 +89,17 @@ var $_SERVER = new Proxy({}, {
 var $_SESSION = {};
 var $_jst_session = null;
 var $_val_input = {};
+
+function is_https_request()
+{
+  var https = getenv('HTTPS');
+  if(https === false || https === undefined || https === null)
+    return false;
+
+  var value = String(https).toLowerCase();
+  return (value === 'on' || value === '1' || value === 'true');
+}
+
 function session_start()
 {
   if($_jst_session)
@@ -99,11 +110,10 @@ function session_start()
     return;
   }
   ccsp_session.start();
-  var host = getenv('HTTPS');
-  if (host == false)
-      var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
-  else
+    if (is_https_request())
       var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; secure" + "; httponly";
+    else
+      var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
   header($cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {
@@ -127,11 +137,10 @@ function session_start()
 }
 function session_create(){
   ccsp_session.create();
-  var host = getenv('HTTPS');
-  if (host == false)
-    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
-  else
+  if (is_https_request())
     var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; secure" + "; httponly";
+  else
+    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
   header($cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {

--- a/jsts/jst_prefix.js
+++ b/jsts/jst_prefix.js
@@ -110,11 +110,8 @@ function session_start()
     return;
   }
   ccsp_session.start();
-  var $session_id = ccsp_session.getId();
-  var $cookie = "Set-Cookie: DUKSID=" + $session_id + "; httponly";
-  if (is_https_request())
-    $cookie = "Set-Cookie: DUKSID=" + $session_id + "; secure; httponly";
-  header($cookie);
+  var cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; HttpOnly" + (is_https_request() ? "; Secure" : "");
+  header(cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {
     get: function(obj, prop) {
@@ -137,11 +134,8 @@ function session_start()
 }
 function session_create(){
   ccsp_session.create();
-  var $session_id = ccsp_session.getId();
-  var $cookie = "Set-Cookie: DUKSID=" + $session_id + "; httponly";
-  if (is_https_request())
-    $cookie = "Set-Cookie: DUKSID=" + $session_id + "; secure; httponly";
-  header($cookie);
+  var cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; HttpOnly" + (is_https_request() ? "; Secure" : "");
+  header(cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {
     get: function(obj, prop) {

--- a/jsts/jst_prefix.js
+++ b/jsts/jst_prefix.js
@@ -110,10 +110,10 @@ function session_start()
     return;
   }
   ccsp_session.start();
-    if (is_https_request())
-      var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; secure" + "; httponly";
-    else
-      var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
+  if (is_https_request())
+    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; secure" + "; httponly";
+  else
+    var $cookie = "Set-Cookie: DUKSID=" + ccsp_session.getId() + "; httponly";
   header($cookie);
   $_jst_session = ccsp_session.getData();
   $_SESSION = new Proxy($_jst_session, {

--- a/source/jst_session.c
+++ b/source/jst_session.c
@@ -148,6 +148,8 @@ static duk_ret_t session_start(duk_context *ctx)
   if(!session_identifier[0])
   {
    CosaPhpExtLog("Invalid Session\n");
+   free(session_identifier);
+   session_identifier = NULL;
    RETURN_FALSE;
   }
 


### PR DESCRIPTION
Root Cause:
In jst_prefix.js where session cookie flags were decided by:
getenv('HTTPS') == false check (too loose / incorrect)

If CGI sets HTTPS=off on HTTP requests, that value is not boolean false, so code incorrectly treated it as HTTPS and emitted:
Set-Cookie: DUKSID=...; secure; httponly

Browsers won’t send a Secure cookie over plain HTTP, so next HTTP request has no valid DUKSID, and server sends you to logged out.

Fix: updated jst_prefix.js to use a strict helper:
is_https_request() returns true only for HTTPS values: on, 1, true (case-insensitive)
Secure is added only when truly HTTPS
Used in both session_start() and session_create()