### PR TITLE
fix(cov_docker_script): disable dbus tests for CMake 3.17

### DIFF
--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -80,7 +80,7 @@
         "build": {
           "type": "cmake",
           "build_dir": "build",
-          "cmake_flags": "-DCMAKE_INSTALL_PREFIX=$HOME/usr -DCMAKE_PREFIX_PATH=/usr -DBUILD_FOR_DESKTOP=ON -DCMAKE_BUILD_TYPE=Debug"
+          "cmake_flags": "-DCMAKE_INSTALL_PREFIX=$HOME/usr -DCMAKE_PREFIX_PATH=/usr -DBUILD_FOR_DESKTOP=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=OFF"
         }
       }
     ]

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -80,7 +80,7 @@
         "build": {
           "type": "cmake",
           "build_dir": "build",
-          "cmake_flags": "-DCMAKE_INSTALL_PREFIX=$HOME/usr -DCMAKE_PREFIX_PATH=/usr -DBUILD_FOR_DESKTOP=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=OFF"
+          "cmake_flags": "-DCMAKE_INSTALL_PREFIX=$HOME/usr -DCMAKE_PREFIX_PATH=/usr -DBUILD_FOR_DESKTOP=ON -DCMAKE_BUILD_TYPE=Debug -DDBUS_BUILD_TESTS=OFF"
         }
       }
     ]


### PR DESCRIPTION
The dbus dependency build was failing during CMake configuration because dbus 1.16.2 uses file(CHMOD ...) in its test setup macros, which requires CMake 3.19 while the CI environment provides CMake 3.17.

Add -DDBUS_BUILD_TESTS=OFF to disable test builds for the D-Bus dependency.